### PR TITLE
Refactor Handlers and Enable Stats Introspection

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"github.com/sambarnes/demoware-consumer/metrics"
 	log "github.com/sirupsen/logrus"
+	"time"
 )
 
 func main() {
@@ -10,10 +12,13 @@ func main() {
 	log.SetLevel(log.DebugLevel)
 	metrics.DemowareMetricsURL = "http://localhost:8080/metrics"
 
-	metricHandlers := map[metrics.MetricType]func(done <-chan interface{}, metricStream <-chan interface{}){
-		metrics.LoadAverageMetric:       metrics.HandleLoadAverageMetric,
-		metrics.CPUUsageMetric:          metrics.HandleCPUUsageMetric,
-		metrics.LastKernelUpgradeMetric: metrics.HandleLastKernelUpgradeMetric,
+	loadMetricsHandler := &metrics.LoadMetricsHandler{}
+	cpuMetricsHandler := &metrics.CPUMetricsHandler{}
+	kernelMetricsHandler := &metrics.KernelMetricsHandler{}
+	metricHandlers := map[metrics.MetricType]metrics.Handler{
+		metrics.LoadAverageMetric:       loadMetricsHandler,
+		metrics.CPUUsageMetric:          cpuMetricsHandler,
+		metrics.LastKernelUpgradeMetric: kernelMetricsHandler,
 	}
 	var metricSubscriptions []metrics.MetricType
 	for k, _ := range metricHandlers {
@@ -25,11 +30,32 @@ func main() {
 	ingestedMetrics := metrics.RunGenerator(done)
 	metricStreamsByType := metrics.RunDispatcher(done, metricSubscriptions, ingestedMetrics)
 	for metricType, handler := range metricHandlers {
-		go handler(done, metricStreamsByType[metricType])
+		log.Debug(fmt.Sprintf("Starting %v handler...", metricType))
+		go metrics.RunMetricStreamHandler(done, metricStreamsByType[metricType], handler)
 	}
 
-	select {
-	// TODO: run a server for outsiders to query current stats of those handler goroutines,
-	//		 or make metrics available to prometheus (if available for the project)
+introspectionLoop:
+	for {
+		select {
+		case <-done:
+			break introspectionLoop
+		case <-time.After(5 * time.Second):
+			//
+			loadStats := loadMetricsHandler.CurrentStats()
+			log.WithFields(log.Fields{
+				"min": loadStats.Min,
+				"max": loadStats.Max,
+			}).Debug("Current LoadStats")
+
+			cpuStats := cpuMetricsHandler.CurrentStats()
+			log.WithFields(log.Fields{
+				"averages": cpuStats.Averages,
+			}).Debug("Current CPUUsageStats")
+
+			kernelStats := kernelMetricsHandler.CurrentStats()
+			log.WithFields(log.Fields{
+				"most_recent": kernelStats.MostRecent,
+			}).Debug("Current KernelUpgradeStats")
+		}
 	}
 }

--- a/metrics/dispatcher_test.go
+++ b/metrics/dispatcher_test.go
@@ -1,64 +1,35 @@
 package metrics
 
-import "testing"
+import (
+	"testing"
+)
 
-func TestRunDispatcher(t *testing.T) {
-	t.Run("CreateSubscriptionStreams", func(t *testing.T) {
-		done := make(chan interface{})
-		resultStream := make(chan Result)
-		defer close(done)
-		defer close(resultStream)
+func TestResultStreamDispatcher_Dispatch(t *testing.T) {
+	dispatcher := &ResultStreamDispatcher{}
+	subscriptionStream := dispatcher.Subscribe(LoadAverageMetric)
 
-		metricSubscriptions := []MetricType{
-			LoadAverageMetric,
-			CPUUsageMetric,
-			LastKernelUpgradeMetric,
-		}
-		metricStreamsByType := RunDispatcher(done, metricSubscriptions, resultStream)
-		for _, metricType := range metricSubscriptions {
-			if _, ok := metricStreamsByType[metricType]; !ok {
-				t.Errorf("Missing %v stream", metricType)
-			}
-		}
-	})
-	t.Run("DispatchesCorrectly", func(t *testing.T) {
-		done := make(chan interface{})
-		defer close(done)
+	good := Metric{LoadAverageMetric, MetricPayload{}}
+	bad := Metric{CPUUsageMetric, MetricPayload{}}
+	batch := []Metric{
+		good,
+		good,
+		bad,
+		bad,
+		bad,
+		good,
+		good,
+	}
+	go func() {
+		dispatcher.Dispatch(batch)
+		dispatcher.Close()
+	}()
 
-		metricSubscriptions := []MetricType{LoadAverageMetric}
-		resultStream := make(chan Result)
-		metricStreamsByType := RunDispatcher(done, metricSubscriptions, resultStream)
-		good := Metric{LoadAverageMetric, MetricPayload{}}
-		bad := Metric{CPUUsageMetric, MetricPayload{}}
-		resultStream <- Result{
-			Metrics: []Metric{
-				good,
-				good,
-				bad,
-				bad,
-				bad,
-				good,
-				good,
-			},
-		}
-		close(resultStream)
-
-		metricsExpected := 4
-		metricsObserved := 0
-	loop:
-		for {
-			select {
-			case <-done:
-				break loop
-			case _, ok := <-metricStreamsByType[LoadAverageMetric]:
-				if ok == false {
-					break loop
-				}
-				metricsObserved++
-			}
-		}
-		if metricsObserved != metricsExpected {
-			t.Errorf("unexpected metrics observed: %v != %v (observed, expected)", metricsObserved, metricsExpected)
-		}
-	})
+	metricsExpected := 4
+	metricsObserved := 0
+	for range subscriptionStream {
+		metricsObserved++
+	}
+	if metricsObserved != metricsExpected {
+		t.Errorf("unexpected metrics observed: %v != %v (observed, expected)", metricsObserved, metricsExpected)
+	}
 }

--- a/metrics/generator.go
+++ b/metrics/generator.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // TODO: better configuration mangagement for remote API url
@@ -35,9 +33,6 @@ const (
 )
 
 func runGenerator(done <-chan interface{}) <-chan interface{} {
-	log.WithFields(log.Fields{
-		"demowareMetricsURL": DemowareMetricsURL,
-	}).Debug("Starting metric ingestion...")
 	return repeatFn(done, ingest)
 }
 
@@ -47,7 +42,7 @@ func RunGenerator(done <-chan interface{}) <-chan Result {
 	return toResult(done, runGenerator(done))
 }
 
-// RunGeneratorN calls the metrics API n times and returns a channel that
+// RunGeneratorN calls the metrics API N times and returns a channel that
 // streams those responses as Result structs
 func RunGeneratorN(done <-chan interface{}, n int) <-chan Result {
 	return toResult(done, take(done, runGenerator(done), n))

--- a/metrics/handlers.go
+++ b/metrics/handlers.go
@@ -27,7 +27,7 @@ func RunMetricStreamHandler(done <-chan interface{}, metricStream <-chan interfa
 // LoadMetricsHandler handles all "load_avg" metrics and manages LoadStats
 type LoadMetricsHandler struct {
 	mu    sync.RWMutex
-	Stats LoadStats
+	stats LoadStats
 }
 
 // LoadStats keeps track of the min and max load seen
@@ -46,7 +46,7 @@ func (h *LoadMetricsHandler) Handle(metric interface{}) error {
 	if ok == false {
 		return fmt.Errorf("failed to cast metric to float64")
 	}
-	return h.Stats.Update(load)
+	return h.stats.Update(load)
 }
 
 // CurrentStats returns the current LoadStats in a concurrent-safe manner
@@ -54,7 +54,7 @@ func (h LoadMetricsHandler) CurrentStats() LoadStats {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
-	return h.Stats
+	return h.stats
 }
 
 // Update determines if the newLoadMetric is the new maximum or minimum and if
@@ -74,7 +74,7 @@ func (s *LoadStats) Update(newLoadMetric float64) error {
 // CPUMetricsHandler handles all "cpu_usage" metrics and manages CPUUsageStats
 type CPUMetricsHandler struct {
 	mu    sync.RWMutex
-	Stats CPUUsageStats
+	stats CPUUsageStats
 }
 
 // CPUUsageStats keeps track of the running average CPU usage per core
@@ -98,7 +98,7 @@ func (h *CPUMetricsHandler) Handle(metric interface{}) error {
 	if err != nil {
 		return err
 	}
-	return h.Stats.Update(usages)
+	return h.stats.Update(usages)
 }
 
 // CurrentStats returns the current CPUUsageStats in a concurrent-safe manner
@@ -106,7 +106,8 @@ func (h CPUMetricsHandler) CurrentStats() CPUUsageStats {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
-	return h.Stats
+	// TODO: return deep copy of struct
+	return h.stats
 }
 
 // Update calculates the new average CPU usage for each core
@@ -132,7 +133,7 @@ func (s *CPUUsageStats) Update(usages []float64) error {
 // KernelMetricsHandler handles all "last_kernel_upgrade" metrics and manages KernelUpgradeStats
 type KernelMetricsHandler struct {
 	mu    sync.RWMutex
-	Stats KernelUpgradeStats
+	stats KernelUpgradeStats
 }
 
 // KernelUpgradeStats keeps track of the most recent timestamp seen
@@ -150,7 +151,7 @@ func (h *KernelMetricsHandler) Handle(metric interface{}) error {
 	if ok == false {
 		return fmt.Errorf("failed to cast metric to string")
 	}
-	return h.Stats.Update(timestamp)
+	return h.stats.Update(timestamp)
 }
 
 // CurrentStats returns the current KernelUpgradeStats in a concurrent-safe manner
@@ -158,7 +159,7 @@ func (h KernelMetricsHandler) CurrentStats() KernelUpgradeStats {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
-	return h.Stats
+	return h.stats
 }
 
 // Update takes a new timestamp string and compares it against the current

--- a/metrics/handlers.go
+++ b/metrics/handlers.go
@@ -32,7 +32,7 @@ type LoadMetricsHandler struct {
 
 // LoadStats keeps track of the min and max load seen
 type LoadStats struct {
-	n   int
+	N   int
 	Min float64
 	Max float64
 }
@@ -60,8 +60,8 @@ func (h LoadMetricsHandler) CurrentStats() LoadStats {
 // Update determines if the newLoadMetric is the new maximum or minimum and if
 // so, changes that value
 func (s *LoadStats) Update(newLoadMetric float64) error {
-	s.n++
-	if s.n == 1 {
+	s.N++
+	if s.N == 1 {
 		s.Min, s.Max = newLoadMetric, newLoadMetric
 	} else if newLoadMetric < s.Min {
 		s.Min = newLoadMetric
@@ -79,9 +79,9 @@ type CPUMetricsHandler struct {
 
 // CPUUsageStats keeps track of the running average CPU usage per core
 type CPUUsageStats struct {
-	n        int
 	cpuCount int
 	totals   []float64
+	N        int
 	Averages []float64
 }
 
@@ -112,20 +112,20 @@ func (h CPUMetricsHandler) CurrentStats() CPUUsageStats {
 
 // Update calculates the new average CPU usage for each core
 func (s *CPUUsageStats) Update(usages []float64) error {
-	if 0 < s.n && len(usages) != s.cpuCount {
+	if 0 < s.N && len(usages) != s.cpuCount {
 		// Assumption: constant CPU count for all requests
 		return fmt.Errorf("invalid length of usages array: expected %v, got %v", s.cpuCount, len(usages))
 	}
 
-	s.n++
-	if s.n == 1 {
+	s.N++
+	if s.N == 1 {
 		s.cpuCount = len(usages)
 		s.totals = make([]float64, s.cpuCount)
 		s.Averages = make([]float64, s.cpuCount)
 	}
 	for i, usage := range usages {
 		s.totals[i] += usage
-		s.Averages[i] = s.totals[i] / float64(s.n)
+		s.Averages[i] = s.totals[i] / float64(s.N)
 	}
 	return nil
 }
@@ -138,7 +138,7 @@ type KernelMetricsHandler struct {
 
 // KernelUpgradeStats keeps track of the most recent timestamp seen
 type KernelUpgradeStats struct {
-	n          int
+	N          int
 	MostRecent time.Time
 }
 
@@ -170,7 +170,7 @@ func (s *KernelUpgradeStats) Update(newTimestamp string) error {
 		return fmt.Errorf("unable to parse newTimestamp: %v", err)
 	}
 
-	s.n++
+	s.N++
 	if newTime.After(s.MostRecent) {
 		// Assumption: "keep track of the most recent timestamp" means comparing timestamps rather
 		// than just storing the timestamp that was received most recently. Even though in the case

--- a/metrics/handlers.go
+++ b/metrics/handlers.go
@@ -106,8 +106,13 @@ func (h CPUMetricsHandler) CurrentStats() CPUUsageStats {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
-	// TODO: return deep copy of struct
-	return h.stats
+	// TODO: evaluate use of a deep copy library
+	return CPUUsageStats{
+		cpuCount: h.stats.cpuCount,
+		totals:   append([]float64{}, h.stats.totals...),
+		N:        h.stats.N,
+		Averages: append([]float64{}, h.stats.Averages...),
+	}
 }
 
 // Update calculates the new average CPU usage for each core

--- a/metrics/handlers_test.go
+++ b/metrics/handlers_test.go
@@ -8,6 +8,37 @@ import (
 	"time"
 )
 
+func TestLoadMetricsHandler_CurrentStats(t *testing.T) {
+	handler := LoadMetricsHandler{}
+	statsCopy := handler.CurrentStats()
+	statsCopy.Max = 10
+	newCopy := handler.CurrentStats()
+	if newCopy.Max != 0 {
+		t.Errorf("internal stats modified by external code")
+	}
+}
+
+func TestCPUMetricsHandler_CurrentStats(t *testing.T) {
+	handler := CPUMetricsHandler{stats: CPUUsageStats{Averages: []float64{0}}}
+	statsCopy := handler.CurrentStats()
+	statsCopy.Averages[0] = 1
+	newCopy := handler.CurrentStats()
+	if newCopy.Averages[0] != 0 {
+		t.Errorf("internal stats modified by external code")
+	}
+}
+
+func TestKernelMetricsHandler_CurrentStats(t *testing.T) {
+	handler := KernelMetricsHandler{}
+	statsCopy := handler.CurrentStats()
+	statsCopy.MostRecent = time.Now()
+	newCopy := handler.CurrentStats()
+	zeroTimestamp := time.Time{}
+	if newCopy.MostRecent != zeroTimestamp {
+		t.Errorf("internal stats modified by external code")
+	}
+}
+
 func TestLoadStats_Update(t *testing.T) {
 	testCases := []struct {
 		Metrics     []float64

--- a/metrics/handlers_test.go
+++ b/metrics/handlers_test.go
@@ -80,8 +80,8 @@ func TestLoadStats_Update(t *testing.T) {
 					t.Fatalf("unexpected error in stats.Update(): %v", err)
 				}
 			}
-			if stats.n != len(testCase.Metrics) {
-				t.Errorf("unexpected stats.n: %v != %v (observed, expected)", stats.n, len(testCase.Metrics))
+			if stats.N != len(testCase.Metrics) {
+				t.Errorf("unexpected stats.N: %v != %v (observed, expected)", stats.N, len(testCase.Metrics))
 			}
 			if stats.Max != testCase.ExpectedMax {
 				t.Errorf("unexpected stats.Max: %v != %v (observed, expected)", stats.Max, testCase.ExpectedMax)
@@ -132,8 +132,8 @@ func TestCPUUsageStats_Update(t *testing.T) {
 					t.Fatalf("unexpected error in stats.Update(): %v", err)
 				}
 			}
-			if stats.n != len(testCase.Metrics) {
-				t.Errorf("unexpected stats.n: %v != %v (observed, expected)", stats.n, len(testCase.Metrics))
+			if stats.N != len(testCase.Metrics) {
+				t.Errorf("unexpected stats.N: %v != %v (observed, expected)", stats.N, len(testCase.Metrics))
 			}
 			if !reflect.DeepEqual(stats.totals, testCase.ExpectedTotals) {
 				t.Errorf("unexpected stats.totals: %v != %v (observed, expected)", stats.totals, testCase.ExpectedTotals)
@@ -157,8 +157,8 @@ func TestCPUUsageStats_Update(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error in stats.Update(), got none")
 		}
-		if stats.n != 1 {
-			t.Errorf("unexpected stats.n: should not increment when an error is raised in stats.Update")
+		if stats.N != 1 {
+			t.Errorf("unexpected stats.N: should not increment when an error is raised in stats.Update")
 		}
 	})
 }
@@ -211,8 +211,8 @@ func TestKernelUpgradeStats_Update(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error in stats.Update(), got none")
 		}
-		if stats.n != 0 {
-			t.Errorf("unexpected stats.n: should not increment when an error is raised in stats.Update")
+		if stats.N != 0 {
+			t.Errorf("unexpected stats.N: should not increment when an error is raised in stats.Update")
 		}
 	})
 }

--- a/metrics/helpers.go
+++ b/metrics/helpers.go
@@ -1,5 +1,7 @@
 package metrics
 
+import "fmt"
+
 // repeatFn is a helper metrics function that calls the function passed to it
 // indefinitely until told to stop
 func repeatFn(done <-chan interface{}, fn func() interface{}) <-chan interface{} {
@@ -75,10 +77,14 @@ func toResult(done <-chan interface{}, valueStream <-chan interface{}) <-chan Re
 }
 
 // toFloat64Array converts the given []interface{} to []float64
-func toFloat64Array(arr []interface{}) []float64 {
+func toFloat64Array(arr []interface{}) ([]float64, error) {
 	result := make([]float64, len(arr))
 	for i, x := range arr {
-		result[i] = x.(float64)
+		f, ok := x.(float64)
+		if ok == false {
+			return nil, fmt.Errorf("failed to cast element to float64")
+		}
+		result[i] = f
 	}
-	return result
+	return result, nil
 }


### PR DESCRIPTION
- Refactor Dispatcher and Handlers into a more proper interface that can be distributed as separate services later on
- Add functionality for getting the current stats of each handler

For stats introspection, I tried to avoid mutex's initially (here: #1) but my design felt hairy so I opted for the simpler route with locks.